### PR TITLE
Add Synapse Spring support

### DIFF
--- a/simulationcraft/core.lua
+++ b/simulationcraft/core.lua
@@ -352,6 +352,16 @@ local function ParseItemStatsFromTooltip(link)
     return stat_begin .. stat_str
 end
 
+local function SynapseCheck()
+    local synapseName, _ = GetSpellInfo(141330) 
+
+    if string.find(GetItemSpell(GetInventoryItemLink("player", 10)), synapseName) then
+        return true
+    else 
+        return false
+    end
+end
+
 function Simulationcraft:GetItemStuffs()
     local items = {}
     for slotNum=1, #slotNames do
@@ -521,6 +531,11 @@ function Simulationcraft:GetItemStuffs()
           --print('#sockets = '..numSockets .. ', bonus = ' .. tostring(useBonus))
           --print( simcItemStr )
         end
+
+        if slotNum == 9 and SynapseCheck() then 
+            simcItemStr = simcItemStr .. ",addon=synapse_springs_mark_ii"
+        end
+
         items[slotNum] = simcItemStr
     end
     

--- a/simulationcraft/core.lua
+++ b/simulationcraft/core.lua
@@ -354,11 +354,12 @@ end
 
 local function SynapseCheck()
     local synapseName, _ = GetSpellInfo(141330) 
-
-    if string.find(GetItemSpell(GetInventoryItemLink("player", 10)), synapseName) then
-        return true
-    else 
-        return false
+    if GetItemSpell(GetInventoryItemLink("player", 10)) then
+        if string.find(GetItemSpell(GetInventoryItemLink("player", 10)), synapseName) then
+            return true
+        else 
+            return false
+        end
     end
 end
 


### PR DESCRIPTION
Synapse Springs support was missing so hacked together something quickly.

Would normally use the item link string but Synapse Springs isn't an enchantment so we need to cheese stuff.
Should work without localization, but maybe not.