### PR TITLE
fix bloodelf race parsing

### DIFF
--- a/simulationcraft/core.lua
+++ b/simulationcraft/core.lua
@@ -551,7 +551,11 @@ function Simulationcraft:PrintSimcProfile()
     local playerLevel = UnitLevel('player')
     local _, playerRace = UnitRace('player')
     local playerSpec, role
-    local specId = GetSpecialization()    
+    local specId = GetSpecialization()
+    -- change bloodelf string to be compatible with simc parsing
+    if (string.lower(playerRace) == 'bloodelf') then
+        playerRace = 'blood_elf'
+    end    
     if specId then
       _, playerSpec,_,_,_,role = GetSpecializationInfo(specId)
     end

--- a/simulationcraft/core.lua
+++ b/simulationcraft/core.lua
@@ -552,10 +552,13 @@ function Simulationcraft:PrintSimcProfile()
     local _, playerRace = UnitRace('player')
     local playerSpec, role
     local specId = GetSpecialization()
-    -- change bloodelf string to be compatible with simc parsing
+    -- change elf race strings to be compatible with simc parsing
     if (string.lower(playerRace) == 'bloodelf') then
         playerRace = 'blood_elf'
-    end    
+    end
+    if (string.lower(playerRace) == 'nightelf') then
+        playerRace = 'night_elf'
+    end
     if specId then
       _, playerSpec,_,_,_,role = GetSpecializationInfo(specId)
     end


### PR DESCRIPTION
Currently, the simc client fails to parse the generated race string for Blood Elf ('bloodelf'), it will generate the error message 'unknown race string specified'.

This change alters the race string in a way that it meets the simc client's expected race ('blood_elf')

A little background on the issue:
UnitRace returns both the localized race name ("Blood Elf" for English clients) as well as the localization-independent race name. 
The latter is (rightfully) being stored, but it has the quirk of removing the space and returning "BloodElf" instead. As such, the tokenize function fails to replace the expected space, resulting in 'bloodelf' instead of the expected/required 'blood_elf'